### PR TITLE
Changed form key name to upload images correct

### DIFF
--- a/src/components/Input/FileInput.tsx
+++ b/src/components/Input/FileInput.tsx
@@ -84,7 +84,7 @@ const FileInputBase: ForwardRefRenderFunction<
 
       const formData = new FormData();
 
-      formData.append(event.target.name, event.target.files[0]);
+      formData.append('image', event.target.files[0]);
       formData.append('key', process.env.NEXT_PUBLIC_IMGBB_API_KEY);
 
       const { CancelToken } = axios;


### PR DESCRIPTION
Accordding with imgbb docs, the prop to send images is "image", but the prop sent is "file", ocurring erros to send images to api.

![image](https://user-images.githubusercontent.com/49066917/143007783-2c67c23a-0cdf-48ec-9cee-635f63a07de9.png)

Adjusted to send prop "image" instead "file", fixing erros.